### PR TITLE
Adding hostnet and tolerations.

### DIFF
--- a/distribution/deployment.cue
+++ b/distribution/deployment.cue
@@ -35,6 +35,10 @@ import (
 				terminationGracePeriodSeconds: 120
 				securityContext: fsGroup: 1337
 				serviceAccountName: _spec.name
+				hostNetwork:        true
+				tolerations: [{
+					operator: "Exists"
+				}]
 				volumes: [{
 					emptyDir: {}
 					name: "data"
@@ -45,9 +49,6 @@ import (
 				containers: _containers
 				if _spec.affinity != _|_ {
 					affinity: _spec.affinity
-				}
-				if _spec.tolerations != _|_ {
-					tolerations: _spec.tolerations
 				}
 			}
 		}


### PR DESCRIPTION
In this weeks episode of echo office hours I was attempting to use flux-aio as a clusterresourceset. It worked great except that the resulting deployment wasn't configured to use hostNetwork and didn't tolerate the node not ready taint.

This change adds those so that flux-aio can be used in a cluster where there is not yet a deployed cni.

Signed-off-by: Duffie Cooley <dcooley@isovalent.com>