### PR TITLE
Update host ports mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ Waiting for deployment "flux" rollout to finish: 0 of 1 updated replicas are ava
 deployment "flux" successfully rolled out
 ```
 
+The Flux pod binds to the following ports on the host network:
+
+- `9292` notification-controller webhook receiver endpoint
+- `9690` notification-controller events receiver endpoint
+- `9790` source-controller storage endpoint
+- `9791-9799` metrics, liveness and readiness endpoints
+
 ### Configure Flux self-update
 
 Configure Flux to update itself from

--- a/distribution/flux.cue
+++ b/distribution/flux.cue
@@ -73,7 +73,8 @@ customresourcedefinition: [string]: apiextensions.#CustomResourceDefinition
 		"\(spec.name)-namespace":          #Namespace & {_spec:          spec}
 		"\(spec.name)-serviceaccount":     #ServiceAccount & {_spec:     spec}
 		"\(spec.name)-clusterrolebinding": #ClusterRoleBinding & {_spec: spec}
-		"\(spec.name)-service":            #WebhookReceiver & {_spec:    spec}
+		"\(spec.name)-webhookreceiver":    #WebhookReceiver & {_spec:    spec}
+		"\(spec.name)-sourceserver":       #SourceServer & {_spec:       spec}
 		"\(spec.name)-deployment":         #Deployment & {
 			_spec:       spec
 			_containers: containers

--- a/distribution/helm-controller.cue
+++ b/distribution/helm-controller.cue
@@ -12,17 +12,17 @@ import (
 	imagePullPolicy: "IfNotPresent"
 	securityContext: _spec.securityContext
 	ports: [{
-		containerPort: 8082
-		name:          "http-prom"
+		containerPort: 9795
+		name:          "http-prom-hc"
 		protocol:      "TCP"
 	}, {
-		containerPort: 9442
-		name:          "healthz"
+		containerPort: 9796
+		name:          "healthz-hc"
 		protocol:      "TCP"
 	}]
 	env: [{
 		name:  "SOURCE_CONTROLLER_LOCALHOST"
-		value: "localhost:9090"
+		value: "localhost:9790"
 	}, {
 		name: "RUNTIME_NAMESPACE"
 		valueFrom: fieldRef: fieldPath: "metadata.namespace"
@@ -32,17 +32,17 @@ import (
 		"--log-level=\(_spec.logLevel)",
 		"--log-encoding=json",
 		"--enable-leader-election=true",
-		"--metrics-addr=:8082",
-		"--health-addr=:9442",
-		"--events-addr=http://localhost:9080",
+		"--metrics-addr=:9795",
+		"--health-addr=:9796",
+		"--events-addr=http://localhost:9690",
 	]
 	readinessProbe: httpGet: {
 		path: "/readyz"
-		port: "healthz"
+		port: "healthz-hc"
 	}
 	livenessProbe: httpGet: {
 		path: "/healthz"
-		port: "healthz"
+		port: "healthz-hc"
 	}
 	resources: _spec.resources
 	volumeMounts: [{

--- a/distribution/kustomize-controller.cue
+++ b/distribution/kustomize-controller.cue
@@ -12,17 +12,17 @@ import (
 	imagePullPolicy: "IfNotPresent"
 	securityContext: _spec.securityContext
 	ports: [{
-		containerPort: 8081
-		name:          "http-prom"
+		containerPort: 9793
+		name:          "http-prom-kc"
 		protocol:      "TCP"
 	}, {
-		containerPort: 9441
-		name:          "healthz"
+		containerPort: 9794
+		name:          "healthz-kc"
 		protocol:      "TCP"
 	}]
 	env: [{
 		name:  "SOURCE_CONTROLLER_LOCALHOST"
-		value: "localhost:9090"
+		value: "localhost:9790"
 	}, {
 		name: "RUNTIME_NAMESPACE"
 		valueFrom: fieldRef: fieldPath: "metadata.namespace"
@@ -32,17 +32,17 @@ import (
 		"--log-level=\(_spec.logLevel)",
 		"--log-encoding=json",
 		"--enable-leader-election=true",
-		"--metrics-addr=:8081",
-		"--health-addr=:9441",
-		"--events-addr=http://localhost:9080",
+		"--metrics-addr=:9793",
+		"--health-addr=:9794",
+		"--events-addr=http://localhost:9690",
 	]
 	readinessProbe: httpGet: {
 		path: "/readyz"
-		port: "healthz"
+		port: "healthz-kc"
 	}
 	livenessProbe: httpGet: {
 		path: "/healthz"
-		port: "healthz"
+		port: "healthz-kc"
 	}
 	resources: _spec.resources
 	volumeMounts: [{

--- a/distribution/notification-controller.cue
+++ b/distribution/notification-controller.cue
@@ -12,20 +12,20 @@ import (
 	imagePullPolicy: "IfNotPresent"
 	securityContext: _spec.securityContext
 	ports: [{
-		containerPort: 9080
-		name:          "http"
+		containerPort: 9690
+		name:          "http-nc"
 		protocol:      "TCP"
 	}, {
-		containerPort: 9292
-		name:          "http-webhook"
+		containerPort: 9797
+		name:          "http-webhook-nc"
 		protocol:      "TCP"
 	}, {
-		containerPort: 8083
-		name:          "http-prom"
+		containerPort: 9798
+		name:          "http-prom-nc"
 		protocol:      "TCP"
 	}, {
-		containerPort: 9443
-		name:          "healthz"
+		containerPort: 9799
+		name:          "healthz-nc"
 		protocol:      "TCP"
 	}]
 	env: [{
@@ -34,20 +34,20 @@ import (
 	}]
 	readinessProbe: httpGet: {
 		path: "/readyz"
-		port: "healthz"
+		port: "healthz-nc"
 	}
 	livenessProbe: httpGet: {
 		path: "/healthz"
-		port: "healthz"
+		port: "healthz-nc"
 	}
 	args: [
 		"--watch-all-namespaces",
 		"--log-level=\(_spec.logLevel)",
 		"--log-encoding=json",
 		"--enable-leader-election",
-		"--metrics-addr=:8083",
-		"--health-addr=:9443",
-		"--events-addr=:9080",
+		"--metrics-addr=:9798",
+		"--health-addr=:9799",
+		"--events-addr=:9690",
 	]
 	resources: _spec.resources
 	volumeMounts: [{

--- a/distribution/service.cue
+++ b/distribution/service.cue
@@ -20,7 +20,29 @@ import (
 		ports: [{
 			name:       "http"
 			port:       80
-			targetPort: "http-webhook"
+			targetPort: "http-webhook-nc"
+			protocol:   "TCP"
+		}]
+	}
+}
+
+#SourceServer: corev1.#Service & {
+	_spec:      #FluxSpec
+	apiVersion: "v1"
+	kind:       "Service"
+	metadata: {
+		name:        "source-controller"
+		namespace:   "\(_spec.name)-system"
+		labels:      _spec.labels
+		annotations: _spec.annotations
+	}
+	spec: corev1.#ServiceSpec & {
+		type: "ClusterIP"
+		selector: "app.kubernetes.io/name": _spec.name
+		ports: [{
+			name:       "http"
+			port:       80
+			targetPort: "http-sc"
 			protocol:   "TCP"
 		}]
 	}

--- a/distribution/source-controller.cue
+++ b/distribution/source-controller.cue
@@ -12,16 +12,16 @@ import (
 	imagePullPolicy: "IfNotPresent"
 	securityContext: _spec.securityContext
 	ports: [{
-		containerPort: 9090
-		name:          "http"
+		containerPort: 9790
+		name:          "http-sc"
 		protocol:      "TCP"
 	}, {
-		containerPort: 8080
-		name:          "http-prom"
+		containerPort: 9791
+		name:          "http-prom-sc"
 		protocol:      "TCP"
 	}, {
-		containerPort: 9440
-		name:          "healthz"
+		containerPort: 9792
+		name:          "healthz-sc"
 		protocol:      "TCP"
 	}]
 	env: [{
@@ -36,16 +36,19 @@ import (
 		"--log-level=\(_spec.logLevel)",
 		"--log-encoding=json",
 		"--enable-leader-election=true",
+		"--metrics-addr=:9791",
+		"--health-addr=:9792",
+		"--storage-addr=:9790",
 		"--storage-path=/data",
 		"--storage-adv-addr=\(_spec.name).$(RUNTIME_NAMESPACE).svc.cluster.local.",
-		"--events-addr=http://localhost:9080",
+		"--events-addr=http://localhost:9690",
 	]
 	livenessProbe: httpGet: {
-		port: "healthz"
+		port: "healthz-sc"
 		path: "/healthz"
 	}
 	readinessProbe: httpGet: {
-		port: "http"
+		port: "http-sc"
 		path: "/"
 	}
 	resources: _spec.resources


### PR DESCRIPTION
The Flux pod binds to the following ports on the host network:

- `9292` notification-controller webhook receiver endpoint
- `9690` notification-controller events receiver endpoint
- `9790` source-controller storage endpoint
- `9791-9799` metrics, liveness and readiness endpoints