### PR TITLE
Add e2e test for CNI with Cilium

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,9 +22,15 @@ jobs:
         run: make tools
       - name: Run CUE validation
         run: make vet
-      - name: Create Kind cluster
-        run: kind create cluster --wait=5m
+      - name: Create cluster without CNI
+        run: kind create cluster --config ./test/cni/kind.yaml
       - name: Install Flux
         run: make install
-      - name: Verify installation
+      - name: Verify Flux installation
         run: flux check
+      - name: Install Cilium with Flux
+        run: kubectl apply -f ./test/cni/cilium.yaml
+      - name: Verify Cilium installation
+        run: kubectl -n kube-system wait helmrelease/cilium --for=condition=ready --timeout=5m
+      - name: Verify CoreDNS availability
+        run: kubectl -n kube-system rollout status deploy/coredns --timeout=5m

--- a/test/cni/cilium.yaml
+++ b/test/cni/cilium.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: cilium
+  namespace: kube-system
+spec:
+  interval: 24h
+  url: https://helm.cilium.io/
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: cilium
+  namespace: kube-system
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: cilium
+      version: "*"
+      sourceRef:
+        kind: HelmRepository
+        name: cilium
+      interval: 12h
+  values:
+    ipam:
+      mode: kubernetes
+    operator:
+      replicas: 1

--- a/test/cni/kind.yaml
+++ b/test/cni/kind.yaml
@@ -1,0 +1,4 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  disableDefaultCNI: true


### PR DESCRIPTION
This PR adds an e2e test to verify that Flux can deploy a CNI plugin.

Test workflow:
- Install Kubernetes Kind without a CNI plugin
- Install Flux on the cluster
- Test that the Flux pod starts without a CNI plugin
- Install Cilium using a Flux HelmRelease
- Wait for Flux to deploy Cilium
- Test that CoreDNS has become healthy

Followup: #8