### PR TITLE
Implement security profile

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,6 +31,6 @@ jobs:
       - name: Install Cilium with Flux
         run: kubectl apply -f ./test/cni/cilium.yaml
       - name: Verify Cilium installation
-        run: kubectl -n kube-system wait helmrelease/cilium --for=condition=ready --timeout=5m
+        run: kubectl -n flux-system wait helmrelease/cilium --for=condition=ready --timeout=5m
       - name: Verify CoreDNS availability
         run: kubectl -n kube-system rollout status deploy/coredns --timeout=5m

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 .ONESHELL:
 .SHELLFLAGS += -e
 
-VERSION:=main
+VERSION:=$(shell grep 'version:' main.cue | awk '{ print $$2 }' | tr -d '"')
 
 .PHONY: tools
 tools: ## Install cue, kind, kubectl, kustomize, FLux CLI and other tools with Homebrew
@@ -21,6 +21,10 @@ uninstall: ## Uninstall Flux
 automate: ## Configure Flux to automatically upgrade itself
 	@cue automate
 
+.PHONY: deautomate
+deautomate: ## Disable Flux automatically upgrade
+	@cue deautomate
+
 .PHONY: vet
 vet: ## Format and vet all CUE definitions
 	@cue fmt ./... && cue vet --all-errors --concrete ./...
@@ -34,7 +38,7 @@ ls: ## List the CUE generated objects
 	@cue ls
 
 .PHONY: publish
-publish:
+publish: ## Push the distribution manifests to the container registry
 	@cue publish
 
 .PHONY: import-k8s
@@ -53,7 +57,8 @@ import-crds:
 
 .PHONY: list-images
 list-images:
-	@flux install --export | grep 'image:'| awk '$2 != "" { print $2}' | sort -u
+	@echo "ghcr.io/fluxcd/flux-cli:$$(flux version --client | awk '$$2 != "" { print $$2}')"
+	@flux install --export | grep 'image:' | awk '$$2 != "" { print $$2}' | sort -u
 
 .PHONY: help
 help:  ## Display this help menu

--- a/distribution/deployment.cue
+++ b/distribution/deployment.cue
@@ -36,9 +36,6 @@ import (
 				securityContext: fsGroup: 1337
 				serviceAccountName: _spec.name
 				hostNetwork:        true
-				tolerations: [{
-					operator: "Exists"
-				}]
 				volumes: [{
 					emptyDir: {}
 					name: "data"
@@ -47,6 +44,9 @@ import (
 					name: "tmp"
 				}]
 				containers: _containers
+				if _spec.tolerations != _|_ {
+					tolerations: _spec.tolerations
+				}
 				if _spec.affinity != _|_ {
 					affinity: _spec.affinity
 				}

--- a/distribution/flux-auto.cue
+++ b/distribution/flux-auto.cue
@@ -61,9 +61,10 @@ import (
 		annotations: _spec.annotations
 	}
 	spec: {
-		interval:      "24h"
-		timeout:       "2m"
-		retryInterval: "1m"
+		interval:           "24h"
+		timeout:            "5m"
+		retryInterval:      "1m"
+		serviceAccountName: "\(_spec.name)"
 		sourceRef: {
 			kind: "OCIRepository"
 			name: "\(_spec.name)-source"

--- a/distribution/flux.cue
+++ b/distribution/flux.cue
@@ -18,6 +18,7 @@ customresourcedefinition: [string]: apiextensions.#CustomResourceDefinition
 		helm:         string
 		notification: string
 	}
+	securityProfile: "restricted" | "privileged"
 
 	labels: *{
 			"app.kubernetes.io/name":    name
@@ -47,6 +48,10 @@ customresourcedefinition: [string]: apiextensions.#CustomResourceDefinition
 		seccompProfile: type: "RuntimeDefault"
 	} | corev1.#PodSecurityContext
 
+	tolerations: *[{
+		operator: "Exists"
+	}] | corev1.#Toleration
+
 	affinity?: nodeAffinity: requiredDuringSchedulingIgnoredDuringExecution: nodeSelectorTerms: [{
 		matchExpressions: [{
 			key:      "kubernetes.io/os"
@@ -54,8 +59,6 @@ customresourcedefinition: [string]: apiextensions.#CustomResourceDefinition
 			values: ["linux"]
 		}]
 	}] | corev1.#Affinity
-
-	tolerations?: [ ...corev1.#Toleration]
 }
 
 #Flux: {

--- a/distribution/helm-controller.cue
+++ b/distribution/helm-controller.cue
@@ -35,6 +35,12 @@ import (
 		"--metrics-addr=:9795",
 		"--health-addr=:9796",
 		"--events-addr=http://localhost:9690",
+		if _spec.securityProfile == "restricted" {
+			"--no-cross-namespace-refs"
+		},
+		if _spec.securityProfile == "restricted" {
+			"--default-service-account=\(_spec.name)"
+		},
 	]
 	readinessProbe: httpGet: {
 		path: "/readyz"

--- a/distribution/kustomize-controller.cue
+++ b/distribution/kustomize-controller.cue
@@ -35,6 +35,15 @@ import (
 		"--metrics-addr=:9793",
 		"--health-addr=:9794",
 		"--events-addr=http://localhost:9690",
+		if _spec.securityProfile == "restricted" {
+			"--no-cross-namespace-refs"
+		},
+		if _spec.securityProfile == "restricted" {
+			"--no-remote-bases"
+		},
+		if _spec.securityProfile == "restricted" {
+			"--default-service-account=\(_spec.name)"
+		},
 	]
 	readinessProbe: httpGet: {
 		path: "/readyz"

--- a/distribution/notification-controller.cue
+++ b/distribution/notification-controller.cue
@@ -48,6 +48,9 @@ import (
 		"--metrics-addr=:9798",
 		"--health-addr=:9799",
 		"--events-addr=:9690",
+		if _spec.securityProfile == "restricted" {
+			"--no-cross-namespace-refs"
+		},
 	]
 	resources: _spec.resources
 	volumeMounts: [{

--- a/main.cue
+++ b/main.cue
@@ -14,6 +14,8 @@ aio: distribution.#Flux & {
 			helm:         "ghcr.io/fluxcd/helm-controller:v0.28.1"
 			notification: "ghcr.io/fluxcd/notification-controller:v0.30.2"
 		}
+		// Enable the multi-tenancy lockdown by setting the securityProfile to 'restricted'
+		securityProfile: "privileged"
 	}
 }
 

--- a/main_tool.cue
+++ b/main_tool.cue
@@ -100,3 +100,35 @@ command: automate: {
 		]
 	}
 }
+
+command: deautomate: {
+	suspend: exec.Run & {
+		cmd: [
+			"flux",
+			"suspend",
+			"kustomization",
+			"\(auto.spec.name)-sync",
+		]
+	}
+	delete: exec.Run & {
+		$after: suspend
+		cmd: [
+			"flux",
+			"delete",
+			"kustomization",
+			"\(auto.spec.name)-sync",
+			"--silent",
+		]
+	}
+	deleteSource: exec.Run & {
+		$after: suspend
+		cmd: [
+			"flux",
+			"delete",
+			"source",
+			"oci",
+			"\(auto.spec.name)-source",
+			"--silent",
+		]
+	}
+}

--- a/test/cni/cilium.yaml
+++ b/test/cni/cilium.yaml
@@ -3,7 +3,7 @@ apiVersion: source.toolkit.fluxcd.io/v1beta2
 kind: HelmRepository
 metadata:
   name: cilium
-  namespace: kube-system
+  namespace: flux-system
 spec:
   interval: 24h
   url: https://helm.cilium.io/
@@ -12,8 +12,10 @@ apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: cilium
-  namespace: kube-system
+  namespace: flux-system
 spec:
+  targetNamespace: kube-system
+  storageNamespace: kube-system
   interval: 30m
   chart:
     spec:


### PR DESCRIPTION
Add a `securityProfile` field to the distribution which accepts one of these values:  `restricted` and `privileged`.  To enable the [Flux multi-tenancy lockdown](https://fluxcd.io/flux/installation/#multi-tenancy-lockdown), set `securityProfile: "restricted"`.