### PR TITLE
Allow fine-tuning of Flux reconcilers

### DIFF
--- a/modules/flux-aio/README.md
+++ b/modules/flux-aio/README.md
@@ -20,7 +20,7 @@ timoni -n flux-system apply flux oci://ghcr.io/stefanprodan/modules/flux-aio
 To install a specific Flux version:
 
 ```shell
-timoni flux-system apply flux oci://ghcr.io/stefanprodan/modules/flux-aio -v 2.0.0-rc.3
+timoni flux-system apply flux oci://ghcr.io/stefanprodan/modules/flux-aio -v 2.1.1
 ```
 
 To change the [default configuration](#configuration),
@@ -53,15 +53,17 @@ flux -n flux-system uninstall
 
 ### General values
 
-| Key                  | Type                               | Default                       | Description                                                                                                                                  |
-|----------------------|------------------------------------|-------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
-| `hostNetwork:`       | `bool`                             | `true`                        | Host network must be enabled on bare-metal clusters without a CNI preinstalled                                                               |
-| `securityProfile:`   | `string`                           | `privileged`                  | To enable Flux multi-tenancy lockdown set the value to `restricted`                                                                          |
-| `workload: provider` | `string`                           | `""`                          | Kubernetes workload identity provider, can be  `aws`, `azure` or `gcp`                                                                       |
-| `workload: identity` | `string`                           | `""`                          | Kubernetes workload ID, can be an AWS Role ARN, Azure Client ID, or GCP Identity Name                                                        |
-| `logLevel:`          | `string`                           | `info`                        | Flux log level can be `debug`, `info`, `error`                                                                                               |
-| `resources:`         | `corev1.#ResourceRequirements`     | `limits: memory: "1Gi"`       | [Kubernetes resource requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers)                     |
-| `tolerations:`       | `[ ...corev1.#Toleration]`         | `[{operator: "Exists"}]`      | [Kubernetes toleration](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration)                                        |
-| `securityContext:`   | `corev1.#SecurityContext`          | `capabilities: drop: ["ALL"]` | [Kubernetes container security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context)                           |
-| `imagePullSecrets:`  | `[...corev1.LocalObjectReference]` | `[]`                          | [Kubernetes image pull secrets](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod)                 |
-| `affinity:`          | `corev1.#Affinity`                 | `{}`                          | [Kubernetes affinity and anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) |
+| Key                     | Type                               | Default                       | Description                                                                                                                                  |
+|-------------------------|------------------------------------|-------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
+| `hostNetwork:`          | `bool`                             | `true`                        | Host network must be enabled on bare-metal clusters without a CNI preinstalled                                                               |
+| `securityProfile:`      | `string`                           | `privileged`                  | To enable Flux multi-tenancy lockdown set the value to `restricted`                                                                          |
+| `workload: provider`    | `string`                           | `""`                          | Kubernetes workload identity provider, can be  `aws`, `azure` or `gcp`                                                                       |
+| `workload: identity`    | `string`                           | `""`                          | Kubernetes workload ID, can be an AWS Role ARN, Azure Client ID, or GCP Identity Name                                                        |
+| `reconcile: concurrent` | `int`                              | `5`                           | The maximum number of parallel reconciliations per controller                                                                                |
+| `reconcile: requeue`    | `int`                              | `30`                          | The interval in seconds at which failing dependencies are reevaluated                                                                        |
+| `logLevel:`             | `string`                           | `info`                        | Flux log level can be `debug`, `info`, `error`                                                                                               |
+| `resources:`            | `corev1.#ResourceRequirements`     | `limits: memory: "1Gi"`       | [Kubernetes resource requests and limits](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers)                     |
+| `tolerations:`          | `[ ...corev1.#Toleration]`         | `[{operator: "Exists"}]`      | [Kubernetes toleration](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration)                                        |
+| `securityContext:`      | `corev1.#SecurityContext`          | `capabilities: drop: ["ALL"]` | [Kubernetes container security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context)                           |
+| `imagePullSecrets:`     | `[...corev1.LocalObjectReference]` | `[]`                          | [Kubernetes image pull secrets](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod)                 |
+| `affinity:`             | `corev1.#Affinity`                 | `{}`                          | [Kubernetes affinity and anti-affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) |

--- a/modules/flux-aio/templates/config.cue
+++ b/modules/flux-aio/templates/config.cue
@@ -49,13 +49,15 @@ import (
 		identity: *"" | string
 	}
 
-	resources: *{
-		requests: {
-			cpu:    "100m"
-			memory: "64Mi"
-		}
-		limits: memory: "1Gi"
-	} | corev1.#ResourceRequirements
+	reconcile: {
+		concurrent: *5 | int
+		requeue:    *30 | int
+	}
+
+	resources: corev1.#ResourceRequirements
+	resources: requests: cpu:    *"100m" | string
+	resources: requests: memory: *"64Mi" | string
+	resources: limits: memory:   *"1Gi" | string
 
 	imagePullSecrets?: [...corev1.LocalObjectReference]
 

--- a/modules/flux-aio/templates/helm-controller.cue
+++ b/modules/flux-aio/templates/helm-controller.cue
@@ -31,10 +31,13 @@ import (
 		"--watch-all-namespaces",
 		"--log-level=\(_spec.logLevel)",
 		"--log-encoding=json",
-		"--enable-leader-election=true",
+		"--enable-leader-election=false",
 		"--metrics-addr=:9795",
 		"--health-addr=:9796",
 		"--events-addr=http://localhost:9690",
+		"--watch-label-selector=!sharding.fluxcd.io/key",
+		"--concurrent=\(_spec.reconcile.concurrent)",
+		"--requeue-dependency=\(_spec.reconcile.requeue)s",
 		if _spec.securityProfile == "restricted" {
 			"--no-cross-namespace-refs"
 		},

--- a/modules/flux-aio/templates/kustomize-controller.cue
+++ b/modules/flux-aio/templates/kustomize-controller.cue
@@ -31,10 +31,13 @@ import (
 		"--watch-all-namespaces",
 		"--log-level=\(_spec.logLevel)",
 		"--log-encoding=json",
-		"--enable-leader-election=true",
+		"--enable-leader-election=false",
 		"--metrics-addr=:9793",
 		"--health-addr=:9794",
 		"--events-addr=http://localhost:9690",
+		"--watch-label-selector=!sharding.fluxcd.io/key",
+		"--concurrent=\(_spec.reconcile.concurrent)",
+		"--requeue-dependency=\(_spec.reconcile.requeue)s",
 		if _spec.securityProfile == "restricted" {
 			"--no-cross-namespace-refs"
 		},

--- a/modules/flux-aio/templates/source-controller.cue
+++ b/modules/flux-aio/templates/source-controller.cue
@@ -35,13 +35,19 @@ import (
 		"--watch-all-namespaces",
 		"--log-level=\(_spec.logLevel)",
 		"--log-encoding=json",
-		"--enable-leader-election=true",
+		"--enable-leader-election=false",
 		"--metrics-addr=:9791",
 		"--health-addr=:9792",
 		"--storage-addr=:9790",
 		"--storage-path=/data",
 		"--storage-adv-addr=\(_spec.metadata.name).$(RUNTIME_NAMESPACE).svc.cluster.local.",
+		"--concurrent=\(_spec.reconcile.concurrent)",
+		"--requeue-dependency=\(_spec.reconcile.requeue)s",
+		"--watch-label-selector=!sharding.fluxcd.io/key",
 		"--events-addr=http://localhost:9690",
+		"--helm-cache-max-size=10",
+		"--helm-cache-ttl=60m",
+		"--helm-cache-purge-interval=5m",
 	]
 	livenessProbe: httpGet: {
 		port: "healthz-sc"


### PR DESCRIPTION
New config options:
- `reconcile: concurrent` sets the maximum number of parallel reconciliations per controller
- `reconcile: requeue` sets the interval in seconds at which failing dependencies are reevaluated

New defaults:
- disable leader election to reduce Kubernetes API calls (AIO prevents multiple pods from running in parallel so leader election is not needed)
- enable Helm index caching for source-controller (reduces memory usage by 50% when using large Helm HTTP repos) 