### PR TITLE
Add pod anti-affinity to prevent host ports conflicts

### DIFF
--- a/modules/flux-aio/templates/config.cue
+++ b/modules/flux-aio/templates/config.cue
@@ -100,17 +100,26 @@ import (
 		seccompProfile: type: "RuntimeDefault"
 	} | corev1.#PodSecurityContext
 
-	tolerations: *[{
-		operator: "Exists"
-	}] | corev1.#Toleration
-
+	affinity: corev1.#Affinity
 	affinity: nodeAffinity: requiredDuringSchedulingIgnoredDuringExecution: nodeSelectorTerms: [{
 		matchExpressions: [{
 			key:      "kubernetes.io/os"
 			operator: "In"
 			values: ["linux"]
 		}]
-	}] | corev1.#Affinity
+	}]
+	affinity: podAntiAffinity: requiredDuringSchedulingIgnoredDuringExecution: [{
+		topologyKey: "kubernetes.io/hostname"
+		labelSelector: matchExpressions: [{
+			key:      "app.kubernetes.io/name"
+			operator: "In"
+			values: [metadata.name]
+		}]
+	}]
+
+	tolerations: *[{
+		operator: "Exists"
+	}] | corev1.#Toleration
 }
 
 // Instance takes the config values and outputs the Kubernetes objects.

--- a/modules/flux-aio/templates/deployment.cue
+++ b/modules/flux-aio/templates/deployment.cue
@@ -51,11 +51,9 @@ import (
 					name: "tmp"
 				}]
 				containers: _containers
+				affinity:   _config.affinity
 				if _config.tolerations != _|_ {
 					tolerations: _config.tolerations
-				}
-				if _config.affinity != _|_ {
-					affinity: _config.affinity
 				}
 				if _config.imagePullSecrets != _|_ {
 					imagePullSecrets: _config.imagePullSecrets


### PR DESCRIPTION
Prevent running more then one Flux pod per Kubernetes node.