### PR TITLE
Add impersonation options to git-sync module 

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,6 +32,10 @@ jobs:
         run: make tools
       - name: Run CUE format
         run: make fmt
+      - name: Vet modules
+        run: |
+          timoni mod vet ./modules/flux-aio --debug
+          timoni mod vet ./modules/flux-git-sync --debug
       - name: Create cluster without CNI
         run: kind create cluster --config ./test/cluster/kind.yaml
       - name: Push modules

--- a/modules/flux-git-sync/README.md
+++ b/modules/flux-git-sync/README.md
@@ -22,15 +22,17 @@ timoni -n flux-system delete my-repo-sync
 
 ## Configuration
 
-| Key                      | Type                  | Default           | Description                                                                               |
-|--------------------------|-----------------------|-------------------|-------------------------------------------------------------------------------------------|
-| `git: url:`              | `string`              | `""`              | Git repository HTTPS URL                                                                  |
-| `git: ref:`              | `string`              | `refs/heads/main` | Git [reference](https://fluxcd.io/flux/components/source/gitrepositories/#name-example)   |
-| `git: token:`            | `string`              | `""`              | Git token (e.g. GitHub PAT or GitLab Deploy Token) for connection to a private repository |
-| `git: path:`             | `string`              | `""`              | Path to the directory containing Kubernetes YAMLs                                         |
-| `git: interval:`         | `int`                 | `"1"`             | Interval in minutes to check for changes upstream                                         |
-| `sync: prune:`           | `bool`                | `true`            | Prune stale resources                                                                     |
-| `sync: wait:`            | `bool`                | `false`           | Wait for resources to become ready                                                        |
-| `sync: timeout:`         | `int`                 | `3`               | Wait timeout in minutes                                                                   |
-| `metadata: labels:`      | `{[ string]: string}` | `{}`              | Custom labels                                                                             |
-| `metadata: annotations:` | `{[ string]: string}` | `{}`              | Custom annotations                                                                        |
+| Key                         | Type                  | Default           | Description                                                                               |
+|-----------------------------|-----------------------|-------------------|-------------------------------------------------------------------------------------------|
+| `git: url:`                 | `string`              | `""`              | Git repository HTTPS URL                                                                  |
+| `git: ref:`                 | `string`              | `refs/heads/main` | Git [reference](https://fluxcd.io/flux/components/source/gitrepositories/#name-example)   |
+| `git: token:`               | `string`              | `""`              | Git token (e.g. GitHub PAT or GitLab Deploy Token) for connection to a private repository |
+| `git: path:`                | `string`              | `""`              | Path to the directory containing Kubernetes YAMLs                                         |
+| `git: interval:`            | `int`                 | `"1"`             | Interval in minutes to check for changes upstream                                         |
+| `sync: prune:`              | `bool`                | `true`            | Prune stale resources                                                                     |
+| `sync: wait:`               | `bool`                | `false`           | Wait for resources to become ready                                                        |
+| `sync: timeout:`            | `int`                 | `3`               | Wait timeout in minutes                                                                   |
+| `sync: serviceAccountName:` | `string`              | `""`              | Service account to impersonate                                                            |
+| `sync: targetNamespace:`    | `string`              | `""`              | Target namespace                                                                          |
+| `metadata: labels:`         | `{[ string]: string}` | `{}`              | Custom labels                                                                             |
+| `metadata: annotations:`    | `{[ string]: string}` | `{}`              | Custom annotations                                                                        |

--- a/modules/flux-git-sync/debug_values.cue
+++ b/modules/flux-git-sync/debug_values.cue
@@ -4,8 +4,14 @@ package main
 
 // Values used by debug_tool.cue.
 // Debug example 'cue cmd -t debug -t name=test -t namespace=test -t mv=1.0.0 -t kv=1.28.0 build'.
-values: git: {
-	url:   "https://github.com/stefanprodan/flux-aio"
-	path:  "./"
-	token: "test"
+values: {
+	git: {
+		url:   "https://github.com/stefanprodan/flux-aio"
+		path:  "./"
+		token: "test"
+	}
+	sync: {
+		serviceAccountName: "flux"
+		targetNamespace:    "flux-system"
+	}
 }

--- a/modules/flux-git-sync/templates/config.cue
+++ b/modules/flux-git-sync/templates/config.cue
@@ -27,6 +27,9 @@ import (
 		prune:   *true | bool
 		wait:    *true | bool
 		timeout: *3 | int
+
+		serviceAccountName?: string
+		targetNamespace?:    string
 	}
 }
 

--- a/modules/flux-git-sync/templates/kustomization.cue
+++ b/modules/flux-git-sync/templates/kustomization.cue
@@ -19,5 +19,11 @@ import (
 		prune:         _config.sync.prune
 		wait:          _config.sync.wait
 		timeout:       "\(_config.sync.timeout)m"
+		if _config.sync.serviceAccountName != _|_ {
+			serviceAccountName: _config.sync.serviceAccountName
+		}
+		if _config.sync.targetNamespace != _|_ {
+			targetNamespace: _config.sync.targetNamespace
+		}
 	}
 }


### PR DESCRIPTION
Changes:
- Add `serviceAccountName` and `targetNamespace` to `flux-git-sync` options
- Vet modules in CI using the debug values