### PR TITLE
Allow configuring post build variable substitution

### DIFF
--- a/modules/flux-git-sync/README.md
+++ b/modules/flux-git-sync/README.md
@@ -22,17 +22,18 @@ timoni -n flux-system delete my-repo-sync
 
 ## Configuration
 
-| Key                         | Type                  | Default           | Description                                                                               |
-|-----------------------------|-----------------------|-------------------|-------------------------------------------------------------------------------------------|
-| `git: url:`                 | `string`              | `""`              | Git repository HTTPS URL                                                                  |
-| `git: ref:`                 | `string`              | `refs/heads/main` | Git [reference](https://fluxcd.io/flux/components/source/gitrepositories/#name-example)   |
-| `git: token:`               | `string`              | `""`              | Git token (e.g. GitHub PAT or GitLab Deploy Token) for connection to a private repository |
-| `git: path:`                | `string`              | `""`              | Path to the directory containing Kubernetes YAMLs                                         |
-| `git: interval:`            | `int`                 | `"1"`             | Interval in minutes to check for changes upstream                                         |
-| `sync: prune:`              | `bool`                | `true`            | Prune stale resources                                                                     |
-| `sync: wait:`               | `bool`                | `false`           | Wait for resources to become ready                                                        |
-| `sync: timeout:`            | `int`                 | `3`               | Wait timeout in minutes                                                                   |
-| `sync: serviceAccountName:` | `string`              | `""`              | Service account to impersonate                                                            |
-| `sync: targetNamespace:`    | `string`              | `""`              | Target namespace                                                                          |
-| `metadata: labels:`         | `{[ string]: string}` | `{}`              | Custom labels                                                                             |
-| `metadata: annotations:`    | `{[ string]: string}` | `{}`              | Custom annotations                                                                        |
+| Key                         | Type                  | Default           | Description                                                                                                                                |
+|-----------------------------|-----------------------|-------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| `git: url:`                 | `string`              | `""`              | Git repository HTTPS URL                                                                                                                   |
+| `git: ref:`                 | `string`              | `refs/heads/main` | Git [reference](https://fluxcd.io/flux/components/source/gitrepositories/#name-example)                                                    |
+| `git: token:`               | `string`              | `""`              | Git token (e.g. GitHub PAT or GitLab Deploy Token) for connection to a private repository                                                  |
+| `git: path:`                | `string`              | `""`              | Path to the directory containing Kubernetes YAMLs                                                                                          |
+| `git: interval:`            | `int`                 | `"1"`             | Interval in minutes to check for changes upstream                                                                                          |
+| `sync: prune:`              | `bool`                | `true`            | Prune stale resources                                                                                                                      |
+| `sync: wait:`               | `bool`                | `false`           | Wait for resources to become ready                                                                                                         |
+| `sync: timeout:`            | `int`                 | `3`               | Wait timeout in minutes                                                                                                                    |
+| `sync: serviceAccountName:` | `string`              | `""`              | Service account to impersonate                                                                                                             |
+| `sync: targetNamespace:`    | `string`              | `""`              | Target namespace                                                                                                                           |
+| `substitute:`               | `{[ string]: string}` | `{}`              | Configure [post build variable substitution](https://fluxcd.io/flux/components/kustomize/kustomizations/#post-build-variable-substitution) |
+| `metadata: labels:`         | `{[ string]: string}` | `{}`              | Custom labels                                                                                                                              |
+| `metadata: annotations:`    | `{[ string]: string}` | `{}`              | Custom annotations                                                                                                                         |

--- a/modules/flux-git-sync/templates/config.cue
+++ b/modules/flux-git-sync/templates/config.cue
@@ -31,6 +31,8 @@ import (
 		serviceAccountName?: string
 		targetNamespace?:    string
 	}
+
+	substitute?: [string]: string
 }
 
 // Instance takes the config values and outputs the Kubernetes objects.

--- a/modules/flux-git-sync/templates/kustomization.cue
+++ b/modules/flux-git-sync/templates/kustomization.cue
@@ -25,5 +25,10 @@ import (
 		if _config.sync.targetNamespace != _|_ {
 			targetNamespace: _config.sync.targetNamespace
 		}
+
+		if _config.substitute != _|_ {
+			postBuild: substitute: _config.substitute
+		}
+
 	}
 }


### PR DESCRIPTION
Extent the flux-git-sync with [post build variable substitution](https://fluxcd.io/flux/components/kustomize/kustomizations/#post-build-variable-substitution) capabilities.