### PR TITLE
Update Kubernetes to v1.28

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # flux-aio
 
-[![flux](https://img.shields.io/badge/flux-v2.1.2-9cf)](https://fluxcd.io)
+[![flux](https://img.shields.io/badge/flux-v2.2.0-9cf)](https://fluxcd.io)
 [![test](https://github.com/stefanprodan/flux-aio/workflows/test/badge.svg)](https://github.com/stefanprodan/flux-aio/actions)
 [![license](https://img.shields.io/github/license/stefanprodan/flux-aio.svg)](https://github.com/stefanprodan/flux-aio/blob/main/LICENSE)
 [![release](https://img.shields.io/github/release/stefanprodan/flux-aio/all.svg)](https://github.com/stefanprodan/flux-aio/releases)
@@ -52,7 +52,7 @@ bundle: {
 		"flux": {
 			module: {
 				url:     "oci://ghcr.io/stefanprodan/modules/flux-aio"
-				version: "2.1.2"
+				version: "2.2.0"
 			}
 			namespace: "flux-system"
 			values: {

--- a/test/cluster/kind.yaml
+++ b/test/cluster/kind.yaml
@@ -2,3 +2,6 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 networking:
   disableDefaultCNI: true
+nodes:
+  - role: control-plane
+    image: kindest/node:v1.28.0


### PR DESCRIPTION
Bump Kubernetes to v1.28.0 for e2e tests.