### PR TITLE
Adopt semver for distribution releases

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,7 +1,8 @@
 name: push
 
 on:
-  workflow_dispatch:
+  push:
+    tags: [ 'v*' ]
 
 permissions:
   contents: read
@@ -28,6 +29,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish Timoni module
-        run: make push-mod
+        run: make push-mod VERSION=$GITHUB_REF_NAME
       - name: Publish Flux default manifests
-        run: make push-manifests
+        run: make push-manifests VERSION=$GITHUB_REF_NAME

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 # Flux All-In-One distribution
 
 .ONESHELL:
-.SHELLFLAGS += -e
+SHELL := bash
+.SHELLFLAGS += -eo pipefail
 
-VERSION:=$(shell grep 'version:' modules/flux-aio/values.cue | awk '{ print $$2 }' | tr -d '"')
+VERSION?=$(shell grep 'version:' modules/flux-aio/values.cue | awk '{ print $$2 }' | tr -d '"')
 
 .PHONY: tools
 tools: ## Install cue, kind, kubectl, Timoni and FLux CLIs

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ This distribution is optimized for running [Flux](https://fluxcd.io) on:
 - Clusters with egress via HTTP/S proxies
 - Serverless clusters for cost optimisation (EKS Fargate)
 
+The versioning of this distribution follows semver with the following format:
+`<flux version>-<distribution release number>`, e.g. `2.2.2-0`.
+
 ## Documentation
 
 - [Distribution specifications](https://timoni.sh/flux-aio/#specifications)
@@ -52,7 +55,7 @@ bundle: {
 		"flux": {
 			module: {
 				url:     "oci://ghcr.io/stefanprodan/modules/flux-aio"
-				version: "2.2.2"
+				version: "latest"
 			}
 			namespace: "flux-system"
 			values: {
@@ -63,6 +66,7 @@ bundle: {
 		}
 	}
 }
+
 ```
 
 Apply the bundle with:


### PR DESCRIPTION
Change the versioning of Flux AIO distribution and all its modules to the following format:
`<flux version>-<distribution release number>`, e.g. `2.2.2-0`.