### PR TITLE
Add Cloud OIDC provider support for OCI Helm repositories

### DIFF
--- a/modules/flux-helm-release/README.md
+++ b/modules/flux-helm-release/README.md
@@ -21,15 +21,17 @@ timoni -n default delete podinfo
 
 ## Configuration
 
-| Key                           | Type                  | Default | Description                    |
-|-------------------------------|-----------------------|---------|--------------------------------|
-| `repository: url:`            | `string`              | `""`    | Helm repository URL            |
-| `repository: auth: username:` | `string`              | `""`    | Helm repository username       |
-| `repository: auth: password:` | `string`              | `""`    | Helm repository password       |
-| `chart: name:`                | `string`              | `""`    | Helm chart name                |
-| `chart: version:`             | `string`              | `"*"`   | Helm chart name semver range   |
-| `sync: interval:`             | `int`                 | `60`    | Reconcile interval             |
-| `sync: serviceAccountName:`   | `string`              | `""`    | Service account to impersonate |
-| `helmValues:`                 | `{...}`               | `{}`    | Helm values                    |
-| `metadata: labels:`           | `{[ string]: string}` | `{}`    | Custom labels                  |
-| `metadata: annotations:`      | `{[ string]: string}` | `{}`    | Custom annotations             |
+| Key                           | Type                  | Default     | Description                                                         |
+|-------------------------------|-----------------------|-------------|---------------------------------------------------------------------|
+| `repository: url:`            | `string`              | `""`        | Helm repository URL                                                 |
+| `repository: provider:`       | `string`              | `"generic"` | Helm repository Cloud OIDC provider, can be `aws`, `azure` or `gcp` |
+| `repository: auth: username:` | `string`              | `""`        | Helm repository username                                            |
+| `repository: auth: password:` | `string`              | `""`        | Helm repository password                                            |
+| `repository: insecure:`       | `bool`                | `false`     | Allow connecting to an insecure (HTTP) OCI registry server          |
+| `chart: name:`                | `string`              | `""`        | Helm chart name                                                     |
+| `chart: version:`             | `string`              | `"*"`       | Helm chart name semver range                                        |
+| `sync: interval:`             | `int`                 | `60`        | Reconcile interval                                                  |
+| `sync: serviceAccountName:`   | `string`              | `""`        | Service account to impersonate                                      |
+| `helmValues:`                 | `{...}`               | `{}`        | Helm values                                                         |
+| `metadata: labels:`           | `{[ string]: string}` | `{}`        | Custom labels                                                       |
+| `metadata: annotations:`      | `{[ string]: string}` | `{}`        | Custom annotations                                                  |

--- a/modules/flux-helm-release/templates/config.cue
+++ b/modules/flux-helm-release/templates/config.cue
@@ -14,11 +14,13 @@ import (
 	metadata: timoniv1.#Metadata & {#Version: moduleVersion}
 
 	repository: {
-		url!: string
+		url!: string & =~"^(http|https|oci)://.*$"
 		auth?: {
 			username!: string
 			password!: string
 		}
+		provider: *"generic" | "aws" | "azure" | "gcp"
+		insecure: *false | bool
 	}
 
 	chart: {

--- a/modules/flux-helm-release/templates/helmrepository.cue
+++ b/modules/flux-helm-release/templates/helmrepository.cue
@@ -18,6 +18,10 @@ import (
 		if #config.repository.auth != _|_ {
 			secretRef: name: "\(#config.metadata.name)-auth"
 		}
+		if #config.repository.insecure {
+			insecure: true
+		}
+		provider: #config.repository.provider
 	}
 }
 


### PR DESCRIPTION
Add `repository: provider` option for configuring ODIC-based auth in the `flux-helm-release` module.

Add `repository: insecure` option for allow Flux to pull charts from an insecure (HTTP) OCI registry server.