### PR TITLE
fix: image pull secrets definition

### DIFF
--- a/modules/flux-aio/templates/config.cue
+++ b/modules/flux-aio/templates/config.cue
@@ -94,7 +94,7 @@ import (
 	resources: requests: memory: *"64Mi" | string & =~"^([0-9]*)?(Mi|Gi)?$"
 	resources: limits: memory:   *"1Gi" | string & =~"^([0-9]*)?(Mi|Gi)?$"
 
-	imagePullSecrets?: [...corev1.LocalObjectReference]
+	imagePullSecrets?: [...corev1.#LocalObjectReference]
 	imagePullSecret?: {
 		registry!: string
 		username!: string


### PR DESCRIPTION
I noticed this when I tried to use this a moment ago:
```
5:34PM ERR build failed for flux:
timoni.instance.config.imagePullSecrets.0: undefined field: LocalObjectReference:
    ./templates/config.cue:97:32
timoni.instance.objects.deployment.spec.template.spec.imagePullSecrets.0: undefined field: LocalObjectReference:
    ./templates/config.cue:97:32
```