### PR TITLE
feat(modules): add depends on to the generated kustomize and helm releases

### DIFF
--- a/modules/flux-git-sync/README.md
+++ b/modules/flux-git-sync/README.md
@@ -38,5 +38,6 @@ timoni -n flux-system delete my-repo-sync
 | `sync: serviceAccountName:` | `string`              | `""`              | Service account to impersonate                                                                                                             |
 | `sync: targetNamespace:`    | `string`              | `""`              | Target namespace                                                                                                                           |
 | `substitute:`               | `{[ string]: string}` | `{}`              | Configure [post build variable substitution](https://fluxcd.io/flux/components/kustomize/kustomizations/#post-build-variable-substitution) |
+| `dependsOn:`                | `{...}                | `{}`              | List of kustomize dependencies                                                                                                             |
 | `metadata: labels:`         | `{[ string]: string}` | `{}`              | Custom labels                                                                                                                              |
 | `metadata: annotations:`    | `{[ string]: string}` | `{}`              | Custom annotations                                                                                                                         |

--- a/modules/flux-git-sync/templates/config.cue
+++ b/modules/flux-git-sync/templates/config.cue
@@ -36,6 +36,11 @@ import (
 	}
 
 	substitute?: [string]: string
+
+	dependsOn?: [...{
+		name:       string
+		namespace?: string
+	}]
 }
 
 // Instance takes the config values and outputs the Kubernetes objects.

--- a/modules/flux-git-sync/templates/kustomization.cue
+++ b/modules/flux-git-sync/templates/kustomization.cue
@@ -30,5 +30,8 @@ import (
 			postBuild: substitute: #config.substitute
 		}
 
+		if #config.dependsOn != _|_ {
+			dependsOn: #config.dependsOn
+		}
 	}
 }

--- a/modules/flux-helm-release/README.md
+++ b/modules/flux-helm-release/README.md
@@ -33,5 +33,6 @@ timoni -n default delete podinfo
 | `sync: interval:`             | `int`                 | `60`        | Reconcile interval                                                  |
 | `sync: serviceAccountName:`   | `string`              | `""`        | Service account to impersonate                                      |
 | `helmValues:`                 | `{...}`               | `{}`        | Helm values                                                         |
+| `dependsOn:`                  | `{...}                | `{}`        | List of kustomize dependencies                                      |
 | `metadata: labels:`           | `{[ string]: string}` | `{}`        | Custom labels                                                       |
 | `metadata: annotations:`      | `{[ string]: string}` | `{}`        | Custom annotations                                                  |

--- a/modules/flux-helm-release/templates/config.cue
+++ b/modules/flux-helm-release/templates/config.cue
@@ -37,6 +37,10 @@ import (
 
 	helmValues?: {...}
 
+	dependsOn?: [...{
+		name:       string
+		namespace?: string
+	}]
 }
 
 // Instance takes the config values and outputs the Kubernetes objects.

--- a/modules/flux-helm-release/templates/helmrelease.cue
+++ b/modules/flux-helm-release/templates/helmrelease.cue
@@ -45,5 +45,9 @@ import (
 		if #config.helmValues != _|_ {
 			values: #config.helmValues
 		}
+
+		if #config.dependsOn != _|_ {
+			dependsOn: #config.dependsOn
+		}
 	}
 }

--- a/modules/flux-oci-sync/README.md
+++ b/modules/flux-oci-sync/README.md
@@ -42,5 +42,6 @@ timoni -n flux-system delete my-repo-sync
 | `sync: serviceAccountName:`    | `string`              | `""`        | Service account to impersonate                                                                                                             |
 | `sync: targetNamespace:`       | `string`              | `""`        | Target namespace                                                                                                                           |
 | `substitute:`                  | `{[ string]: string}` | `{}`        | Configure [post build variable substitution](https://fluxcd.io/flux/components/kustomize/kustomizations/#post-build-variable-substitution) |
+| `dependsOn:`                   | `{...}                | `{}`        | List of kustomize dependencies                                                                                                             |
 | `metadata: labels:`            | `{[ string]: string}` | `{}`        | Custom labels                                                                                                                              |
 | `metadata: annotations:`       | `{[ string]: string}` | `{}`        | Custom annotations                                                                                                                         |

--- a/modules/flux-oci-sync/templates/config.cue
+++ b/modules/flux-oci-sync/templates/config.cue
@@ -54,6 +54,11 @@ import (
 	}
 
 	substitute?: [string]: string
+
+	dependsOn?: [...{
+		name:       string
+		namespace?: string
+	}]
 }
 
 // Instance takes the config values and outputs the Kubernetes objects.

--- a/modules/flux-oci-sync/templates/kustomization.cue
+++ b/modules/flux-oci-sync/templates/kustomization.cue
@@ -28,5 +28,8 @@ import (
 		if #config.substitute != _|_ {
 			postBuild: substitute: #config.substitute
 		}
+		if #config.dependsOn != _|_ {
+			dependsOn: #config.dependsOn
+		}
 	}
 }


### PR DESCRIPTION
This adds a `dependsOn` clause to each of the modules:

- flux-git-sync
- flux-helm-release
- flux-oci-sync