### PR TITLE
Add drift detection and test options to flux-helm-release module

### DIFF
--- a/modules/flux-helm-release/README.md
+++ b/modules/flux-helm-release/README.md
@@ -21,18 +21,21 @@ timoni -n default delete podinfo
 
 ## Configuration
 
-| Key                           | Type                  | Default     | Description                                                         |
-|-------------------------------|-----------------------|-------------|---------------------------------------------------------------------|
-| `repository: url:`            | `string`              | `""`        | Helm repository URL                                                 |
-| `repository: provider:`       | `string`              | `"generic"` | Helm repository Cloud OIDC provider, can be `aws`, `azure` or `gcp` |
-| `repository: auth: username:` | `string`              | `""`        | Helm repository username                                            |
-| `repository: auth: password:` | `string`              | `""`        | Helm repository password                                            |
-| `repository: insecure:`       | `bool`                | `false`     | Allow connecting to an insecure (HTTP) OCI registry server          |
-| `chart: name:`                | `string`              | `""`        | Helm chart name                                                     |
-| `chart: version:`             | `string`              | `"*"`       | Helm chart name semver range                                        |
-| `sync: interval:`             | `int`                 | `60`        | Reconcile interval                                                  |
-| `sync: serviceAccountName:`   | `string`              | `""`        | Service account to impersonate                                      |
-| `helmValues:`                 | `{...}`               | `{}`        | Helm values                                                         |
-| `dependsOn:`                  | `[...{name: string}]` | `{}`        | List of dependencies                                                |
-| `metadata: labels:`           | `{[ string]: string}` | `{}`        | Custom labels                                                       |
-| `metadata: annotations:`      | `{[ string]: string}` | `{}`        | Custom annotations                                                  |
+| Key                           | Type                  | Default      | Description                                                         |
+|-------------------------------|-----------------------|--------------|---------------------------------------------------------------------|
+| `repository: url:`            | `string`              | `""`         | Helm repository URL                                                 |
+| `repository: provider:`       | `string`              | `"generic"`  | Helm repository Cloud OIDC provider, can be `aws`, `azure` or `gcp` |
+| `repository: auth: username:` | `string`              | `""`         | Helm repository username                                            |
+| `repository: auth: password:` | `string`              | `""`         | Helm repository password                                            |
+| `repository: insecure:`       | `bool`                | `false`      | Allow connecting to an insecure (HTTP) OCI registry server          |
+| `chart: name:`                | `string`              | `""`         | Helm chart name                                                     |
+| `chart: version:`             | `string`              | `"*"`        | Helm chart name semver range                                        |
+| `sync: interval:`             | `int`                 | `60`         | Reconcile interval in minutes                                       |
+| `sync: timeout:`              | `int`                 | `5`          | Timeout in minutes                                                  |
+| `sync: serviceAccountName:`   | `string`              | `""`         | Service account to impersonate                                      |
+| `dependsOn:`                  | `[...{name: string}]` | `{}`         | List of dependencies                                                |
+| `driftDetection:`             | `string`              | `"disabled"` | Set drift detection mode, can be `enabled` or `warn`                |
+| `test:`                       | `bool`                | `false`      | Run Helm tests after install and upgrade                            |
+| `helmValues:`                 | `{...}`               | `{}`         | Helm values                                                         |
+| `metadata: labels:`           | `{[ string]: string}` | `{}`         | Custom labels                                                       |
+| `metadata: annotations:`      | `{[ string]: string}` | `{}`         | Custom annotations                                                  |

--- a/modules/flux-helm-release/debug_values.cue
+++ b/modules/flux-helm-release/debug_values.cue
@@ -17,4 +17,6 @@ values: {
 		name:    "podinfo"
 		version: "6.x"
 	}
+
+	driftDetection: "enabled"
 }

--- a/modules/flux-helm-release/templates/config.cue
+++ b/modules/flux-helm-release/templates/config.cue
@@ -31,16 +31,21 @@ import (
 	sync: {
 		retries:             int | *-1
 		interval:            int | *60
+		timeout:             int | *5
 		serviceAccountName?: string
 		targetNamespace?:    string
 	}
 
-	helmValues?: {...}
+	test: bool | *false
+
+	driftDetection?: "enabled" | "warn" | "disabled"
 
 	dependsOn?: [...{
 		name:       string
 		namespace?: string
 	}]
+
+	helmValues?: {...}
 }
 
 // Instance takes the config values and outputs the Kubernetes objects.

--- a/modules/flux-helm-release/templates/helmrelease.cue
+++ b/modules/flux-helm-release/templates/helmrelease.cue
@@ -10,6 +10,7 @@ import (
 	spec: fluxv2.#HelmReleaseSpec & {
 		releaseName: "\(#config.metadata.name)"
 		interval:    "\(#config.sync.interval)m"
+		timeout:     "\(#config.sync.timeout)m"
 
 		if #config.sync.targetNamespace != _|_ {
 			targetNamespace:  "\(#config.sync.targetNamespace)"
@@ -21,6 +22,12 @@ import (
 		}
 
 		chart: {
+			metadata: {
+				labels: #config.metadata.labels
+				if #config.metadata.annotations != _|_ {
+					annotations: #config.metadata.annotations
+				}
+			}
 			spec: {
 				chart:   "\(#config.chart.name)"
 				version: "\(#config.chart.version)"
@@ -42,12 +49,18 @@ import (
 			remediation: retries: #config.sync.retries
 		}
 
+		test: enable: #config.test
+
 		if #config.helmValues != _|_ {
 			values: #config.helmValues
 		}
 
 		if #config.dependsOn != _|_ {
 			dependsOn: #config.dependsOn
+		}
+
+		if #config.driftDetection != _|_ {
+			driftDetection: mode: #config.driftDetection
 		}
 	}
 }


### PR DESCRIPTION
Allow enabling Helm testing and drift detection for Helm releases. Also set the metadata labels and annotations for the generated HelmChart object. 