### PR TITLE
Add OpenShift compatibility

### DIFF
--- a/modules/flux-aio/README.md
+++ b/modules/flux-aio/README.md
@@ -87,6 +87,7 @@ flux -n flux-system uninstall
 | `imagePullSecret: registry:` | `string`                           | `null`                        | Registry address for the generated image pull secret                                                                                                                                     |
 | `imagePullSecret: username:` | `string`                           | `null`                        | Registry username for the generated image pull secret                                                                                                                                    |
 | `imagePullSecret: password:` | `string`                           | `null`                        | Registry password for the generated image pull secret                                                                                                                                    |
+| `compatibility:`             | `string`                           | `kubernetes`                  | Can be set to `openshift` to make the security context compatible with RedHat OpenShift                                                                                                  |                                                                                                 |
 
 ### Controllers
 
@@ -106,4 +107,3 @@ flux -n flux-system uninstall
 | `expose: webhookReceiver:`             | `bool`                         | `false`                                                | Create the `webhook-reciver` Kubernetes Service                                       |
 | `expose: notificationServer:`          | `bool`                         | `false`                                                | Create the `notification-controller` Kubernetes Service                               |
 | `expose: sourceServer:`                | `bool`                         | `false`                                                | Create the `source-controller` Kubernetes Service                                     |
-

--- a/modules/flux-aio/templates/config.cue
+++ b/modules/flux-aio/templates/config.cue
@@ -68,6 +68,8 @@ import (
 
 	hostNetwork: *true | bool
 
+	compatibility: *"kubernetes" | "openshift"
+
 	workload: {
 		provider: *"" | "aws" | "azure" | "gcp"
 		identity: *"" | string

--- a/modules/flux-aio/templates/deployment.cue
+++ b/modules/flux-aio/templates/deployment.cue
@@ -35,7 +35,9 @@ import (
 			spec: corev1.#PodSpec & {
 				priorityClassName:             "system-cluster-critical"
 				terminationGracePeriodSeconds: 120
-				securityContext: fsGroup: 1337
+				if #config.compatibility == "kubernetes" {
+					securityContext: fsGroup: 1337
+				}
 				serviceAccountName: #config.metadata.name
 				hostNetwork:        #config.hostNetwork
 				volumes: [{


### PR DESCRIPTION
Add a config option `compatibility: "openshift"` for making Flux AIO run on OpenShift.

Tested on OpenShift 4.15.0-okd.