### PR TITLE
Generate `OCIRepository` with `flux-helm-release` module

### DIFF
--- a/bundles/flux-tenants.cue
+++ b/bundles/flux-tenants.cue
@@ -9,7 +9,7 @@ bundle: {
 			namespace: "dev-team-apps"
 			values: role: "namespace-admin"
 		}
-		"podinfo": {
+		"podinfo-ks-oci": {
 			module: {
 				url: "oci://ghcr.io/stefanprodan/modules/flux-oci-sync" @timoni(runtime:string:FLUX_OCI_MODULE_URL)
 			}
@@ -32,7 +32,7 @@ bundle: {
 			}
 			namespace: "dev-team-apps"
 			values: {
-				repository: url: "oci://ghcr.io/stefanprodan/charts"
+				repository: url: "https://stefanprodan.github.io/podinfo"
 				chart: name:     "podinfo"
 				sync: {
 					serviceAccountName: "flux"
@@ -49,6 +49,18 @@ bundle: {
 						cpu:     99
 					}
 				}
+			}
+		}
+		"podinfo-hr-oci": {
+			module: {
+				url: "oci://ghcr.io/stefanprodan/modules/flux-helm-release" @timoni(runtime:string:FLUX_HR_MODULE_URL)
+			}
+			namespace: "dev-team-apps"
+			values: {
+				repository: url:          "oci://ghcr.io/stefanprodan/charts"
+				chart: name:              "podinfo"
+				sync: serviceAccountName: "flux"
+				helmValues: replicaCount: 2
 			}
 		}
 	}

--- a/modules/flux-helm-release/templates/config.cue
+++ b/modules/flux-helm-release/templates/config.cue
@@ -1,6 +1,8 @@
 package templates
 
 import (
+	"strings"
+
 	timoniv1 "timoni.sh/core/v1alpha1"
 )
 
@@ -52,12 +54,19 @@ import (
 #Instance: {
 	config: #Config
 
-	objects: {
-		repository: #HelmRepository & {#config: config}
-		release: #HelmRelease & {#config: config}
+	objects: release: #HelmRelease & {#config: config}
+
+	if strings.HasPrefix(config.repository.url, "oci://") {
+		objects: repository: #OCIRepository & {#config: config}
+		if config.repository.auth != _|_ {
+			objects: secret: #OCIRepositoryAuth & {#config: config}
+		}
 	}
 
-	if config.repository.auth != _|_ {
-		objects: secret: #HelmRepositoryAuth & {#config: config}
+	if !strings.HasPrefix(config.repository.url, "oci://") {
+		objects: repository: #HelmRepository & {#config: config}
+		if config.repository.auth != _|_ {
+			objects: secret: #HelmRepositoryAuth & {#config: config}
+		}
 	}
 }

--- a/modules/flux-helm-release/templates/helmrepository.cue
+++ b/modules/flux-helm-release/templates/helmrepository.cue
@@ -1,22 +1,17 @@
 package templates
 
 import (
-	"strings"
-
-	fluxv1 "source.toolkit.fluxcd.io/helmrepository/v1"
+	sourcev1 "source.toolkit.fluxcd.io/helmrepository/v1"
 )
 
-#HelmRepository: fluxv1.#HelmRepository & {
+#HelmRepository: sourcev1.#HelmRepository & {
 	#config:  #Config
 	metadata: #config.metadata
-	spec: fluxv1.#HelmRepositorySpec & {
+	spec: sourcev1.#HelmRepositorySpec & {
 		interval: "12h"
 		url:      #config.repository.url
-		if strings.HasPrefix(#config.repository.url, "oci") {
-			type: "oci"
-		}
 		if #config.repository.auth != _|_ {
-			secretRef: name: "\(#config.metadata.name)-auth"
+			secretRef: name: "\(#config.metadata.name)-helm-auth"
 		}
 		if #config.repository.insecure {
 			insecure: true
@@ -30,7 +25,7 @@ import (
 	apiVersion: "v1"
 	kind:       "Secret"
 	metadata: {
-		name:      "\(#config.metadata.name)-auth"
+		name:      "\(#config.metadata.name)-helm-auth"
 		namespace: #config.metadata.namespace
 		labels:    #config.metadata.labels
 		if #config.metadata.annotations != _|_ {

--- a/modules/flux-helm-release/templates/ocirepository.cue
+++ b/modules/flux-helm-release/templates/ocirepository.cue
@@ -1,0 +1,34 @@
+package templates
+
+import (
+	"strings"
+
+	sourcev1 "source.toolkit.fluxcd.io/ocirepository/v1beta2"
+	timoniv1 "timoni.sh/core/v1alpha1"
+)
+
+#OCIRepository: sourcev1.#OCIRepository & {
+	#config:  #Config
+	metadata: #config.metadata
+	spec: sourcev1.#OCIRepositorySpec & {
+		interval: "\(#config.sync.interval)m"
+		url:      #config.repository.url + "/" + #config.chart.name
+		ref: semver: #config.chart.version
+		provider: #config.repository.provider
+		if #config.repository.auth != _|_ {
+			secretRef: name: "\(#config.metadata.name)-helm-auth"
+		}
+		if #config.repository.insecure {
+			insecure: #config.repository.insecure
+		}
+	}
+}
+
+#OCIRepositoryAuth: timoniv1.#ImagePullSecret & {
+	#config:   #Config
+	#Meta:     #config.metadata
+	#Suffix:   "-helm-auth"
+	#Registry: strings.Split(#config.repository.url, "/")[2]
+	#Username: #config.repository.auth.username
+	#Password: #config.repository.auth.password
+}


### PR DESCRIPTION
When the repository URL points to an OCI registry, the `flux-helm-release` module generates an `OCIRepository` instead of a `HelmRepository/HelmChart`.