### PR TITLE
Add option for extra volumes and volume mounts

### DIFF
--- a/modules/flux-aio/templates/config.cue
+++ b/modules/flux-aio/templates/config.cue
@@ -30,21 +30,25 @@ import (
 		source: {
 			image:      timoniv1.#Image
 			resources?: corev1.#ResourceRequirements
+			extraVolumeMounts: *[] | [...corev1.#VolumeMount]
 		}
 		kustomize: {
 			enabled:    *true | bool
 			image:      timoniv1.#Image
 			resources?: timoniv1.#ResourceRequirements
+			extraVolumeMounts: *[] | [...corev1.#VolumeMount]
 		}
 		helm: {
 			enabled:    *true | bool
 			image:      timoniv1.#Image
 			resources?: timoniv1.#ResourceRequirements
+			extraVolumeMounts: *[] | [...corev1.#VolumeMount]
 		}
 		notification: {
 			enabled:    *true | bool
 			image:      timoniv1.#Image
 			resources?: timoniv1.#ResourceRequirements
+			extraVolumeMounts: *[] | [...corev1.#VolumeMount]
 		}
 	}
 
@@ -138,6 +142,7 @@ import (
 		tolerationSeconds: 300
 	}] | [...corev1.#Toleration]
 
+    extraVolumes: *[] | [...corev1.#Volume]
 }
 
 // Instance takes the config values and outputs the Kubernetes objects.

--- a/modules/flux-aio/templates/deployment.cue
+++ b/modules/flux-aio/templates/deployment.cue
@@ -61,7 +61,7 @@ import (
 							}
 						}
 					}
-				}]
+				}] + #config.extraVolumes
 				containers: _containers
 				affinity:   #config.affinity
 				if #config.tolerations != _|_ {

--- a/modules/flux-aio/templates/helm-controller.cue
+++ b/modules/flux-aio/templates/helm-controller.cue
@@ -59,5 +59,5 @@ import (
 	volumeMounts: [{
 		name:      "tmp"
 		mountPath: "/tmp"
-	}]
+	}] + #config.controllers.helm.extraVolumeMounts
 }

--- a/modules/flux-aio/templates/kustomize-controller.cue
+++ b/modules/flux-aio/templates/kustomize-controller.cue
@@ -63,5 +63,5 @@ import (
 	volumeMounts: [{
 		name:      "tmp"
 		mountPath: "/tmp"
-	}]
+	}] + #config.controllers.kustomize.extraVolumeMounts
 }

--- a/modules/flux-aio/templates/notification-controller.cue
+++ b/modules/flux-aio/templates/notification-controller.cue
@@ -59,5 +59,5 @@ import (
 	volumeMounts: [{
 		name:      "tmp"
 		mountPath: "/tmp"
-	}]
+	}] + #config.controllers.notification.extraVolumeMounts
 }

--- a/modules/flux-aio/templates/source-controller.cue
+++ b/modules/flux-aio/templates/source-controller.cue
@@ -67,5 +67,5 @@ import (
 	}, {
 		name:      "tmp"
 		mountPath: "/tmp"
-	}]
+	}] + #config.controllers.source.extraVolumeMounts
 }


### PR DESCRIPTION
Adds options to configure additional volumes and volume mounts to the containers. This can for instance be used to add custom CA certificates to the source controller.