### PR TITLE
Allow setting the pod security labels on the Flux namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ see [timoni.sh](https://timoni.sh/install/).
 ### Install Flux on self-managed clusters
 
 To deploy Flux AIO on a cluster without a CNI, create a Timoni Bundle file
-named `flux-aio.cue` with the following content: 
+named `flux-aio.cue` with the following content:
 
 ```cue
 bundle: {
@@ -82,6 +82,16 @@ Note that on clusters without `kube-proxy`, you'll have to add the following env
 values: env: {
 	"KUBERNETES_SERVICE_HOST": "<host>"
 	"KUBERNETES_SERVICE_PORT": "<port>"
+}
+```
+
+Note that on [Talos](https://github.com/siderolabs/talos) clusters, you'll have to set the pod security profile to
+`privileged`:
+
+```cue
+values: {
+	hostNetwork:     true
+	podSecurityProfile: "privileged"
 }
 ```
 

--- a/modules/flux-aio/README.md
+++ b/modules/flux-aio/README.md
@@ -88,6 +88,7 @@ flux -n flux-system uninstall
 | `imagePullSecret: username:` | `string`                           | `null`                        | Registry username for the generated image pull secret                                                                                                                                    |
 | `imagePullSecret: password:` | `string`                           | `null`                        | Registry password for the generated image pull secret                                                                                                                                    |
 | `compatibility:`             | `string`                           | `kubernetes`                  | Can be set to `openshift` to make the security context compatible with RedHat OpenShift                                                                                                  |                                                                                                 |
+| `podSecurityProfile:`        | `string`                           | `""`                          | Can be `privileged` or `restricted`, used for setting the `pod-security.kubernetes.io` labels on the namespace                                                                           |
 
 ### Controllers
 

--- a/modules/flux-aio/debug_values.cue
+++ b/modules/flux-aio/debug_values.cue
@@ -63,8 +63,9 @@ values: {
 		identity: "arn:aws:iam::111122223333:role/my-role"
 		provider: "aws"
 	}
-	hostNetwork:     true
-	securityProfile: "privileged"
+	hostNetwork:        true
+	podSecurityProfile: "privileged"
+	securityProfile:    "privileged"
 	resources: {
 		requests: {
 			cpu:    "250m"

--- a/modules/flux-aio/templates/config.cue
+++ b/modules/flux-aio/templates/config.cue
@@ -64,6 +64,8 @@ import (
 
 	securityProfile: "restricted" | "privileged"
 
+	podSecurityProfile: *"" | "restricted" | "privileged"
+
 	logLevel: *"info" | string
 
 	hostNetwork: *true | bool

--- a/modules/flux-aio/templates/namespace.cue
+++ b/modules/flux-aio/templates/namespace.cue
@@ -10,7 +10,14 @@ import (
 	kind:       "Namespace"
 	metadata: {
 		name:        #config.metadata.namespace
-		labels:      #config.metadata.labels
 		annotations: #config.metadata.annotations
+		labels:      #config.metadata.labels
+		if #config.podSecurityProfile != "" {
+			labels: {
+				"pod-security.kubernetes.io/enforce": #config.podSecurityProfile
+				"pod-security.kubernetes.io/warn":    #config.podSecurityProfile
+				"pod-security.kubernetes.io/audit":   #config.podSecurityProfile
+			}
+		}
 	}
 }


### PR DESCRIPTION
Introduce a new config option in the `flux-aio` module called `podSecurityProfile` for setting the `pod-security.kubernetes.io` labels on the namespace where Flux is deployed. 

Add a note in the readme for Talos to set the pod security to `privileged`.

Fix: #97 