### PR TITLE
Made kustomization's reconciliation interval configurable

### DIFF
--- a/modules/flux-git-sync/README.md
+++ b/modules/flux-git-sync/README.md
@@ -34,6 +34,7 @@ timoni -n flux-system delete my-repo-sync
 | `sync: prune:`              | `bool`                | `true`            | Prune stale resources                                                                                                                      |
 | `sync: wait:`               | `bool`                | `false`           | Wait for resources to become ready                                                                                                         |
 | `sync: timeout:`            | `int`                 | `3`               | Wait timeout in minutes                                                                                                                    |
+| `sync: interval:`           | `int`                 | `60`              | Reconciliation interval in minutes                                                                                                         |
 | `sync: retryInterval:`      | `int`                 | `5`               | Retry failed reconciliation interval in minutes                                                                                            |
 | `sync: serviceAccountName:` | `string`              | `""`              | Service account to impersonate                                                                                                             |
 | `sync: targetNamespace:`    | `string`              | `""`              | Target namespace                                                                                                                           |

--- a/modules/flux-git-sync/templates/config.cue
+++ b/modules/flux-git-sync/templates/config.cue
@@ -29,6 +29,7 @@ import (
 		prune:         *true | bool
 		wait:          *true | bool
 		timeout:       *3 | int
+		interval:      *60 | int
 		retryInterval: *5 | int
 
 		serviceAccountName?: string

--- a/modules/flux-git-sync/templates/kustomization.cue
+++ b/modules/flux-git-sync/templates/kustomization.cue
@@ -13,7 +13,7 @@ import (
 			kind: sourcev1.#GitRepository.kind
 			name: #config.metadata.name
 		}
-		interval:      "60m"
+		interval:      "\(#config.sync.interval)m"
 		retryInterval: "\(#config.sync.retryInterval)m"
 		path:          #config.git.path
 		prune:         #config.sync.prune

--- a/modules/flux-oci-sync/README.md
+++ b/modules/flux-oci-sync/README.md
@@ -38,6 +38,7 @@ timoni -n flux-system delete my-repo-sync
 | `sync: prune:`                 | `bool`                | `true`      | Prune stale resources                                                                                                                      |
 | `sync: wait:`                  | `bool`                | `false`     | Wait for resources to become ready                                                                                                         |
 | `sync: timeout:`               | `int`                 | `3`         | Wait timeout in minutes                                                                                                                    |
+| `sync: interval:`              | `int`                 | `60`        | Reconciliation interval in minutes                                                                                                         |
 | `sync: retryInterval:`         | `int`                 | `5`         | Retry failed reconciliation interval in minutes                                                                                            |
 | `sync: serviceAccountName:`    | `string`              | `""`        | Service account to impersonate                                                                                                             |
 | `sync: targetNamespace:`       | `string`              | `""`        | Target namespace                                                                                                                           |

--- a/modules/flux-oci-sync/templates/config.cue
+++ b/modules/flux-oci-sync/templates/config.cue
@@ -47,6 +47,7 @@ import (
 		prune:         *true | bool
 		wait:          *true | bool
 		timeout:       *3 | int
+		interval:      *60 | int
 		retryInterval: *5 | int
 
 		serviceAccountName?: string

--- a/modules/flux-oci-sync/templates/kustomization.cue
+++ b/modules/flux-oci-sync/templates/kustomization.cue
@@ -13,7 +13,7 @@ import (
 			kind: sourcev1.#OCIRepository.kind
 			name: #config.metadata.name
 		}
-		interval:      "60m"
+		interval:      "\(#config.sync.interval)m"
 		retryInterval: "\(#config.sync.retryInterval)m"
 		path:          #config.sync.path
 		prune:         #config.sync.prune


### PR DESCRIPTION
Hi, 

By default, the Kustomization interval is set to 1 hour and is hard coded. 

This MR allow the interval to be configured.

What do you think about it ?
Thanks. 