### PR TITLE
add sync.createNamespace value to flux-helm-release module

### DIFF
--- a/modules/flux-helm-release/README.md
+++ b/modules/flux-helm-release/README.md
@@ -33,6 +33,7 @@ timoni -n default delete podinfo
 | `sync: interval:`             | `int`                 | `60`         | Reconcile interval in minutes                                       |
 | `sync: timeout:`              | `int`                 | `5`          | Timeout in minutes                                                  |
 | `sync: serviceAccountName:`   | `string`              | `""`         | Service account to impersonate                                      |
+| `sync: createNamespace:`      | `bool`                | `false`      | Instructs Helm to create the target namespace if it does not exist  |
 | `sync: disableWait:`          | `bool`                | `false`      | Disables waiting for resource readiness after install/upgrade       |
 | `dependsOn:`                  | `[...{name: string}]` | `{}`         | List of dependencies                                                |
 | `driftDetection:`             | `string`              | `"disabled"` | Set drift detection mode, can be `enabled` or `warn`                |

--- a/modules/flux-helm-release/README.md
+++ b/modules/flux-helm-release/README.md
@@ -33,7 +33,7 @@ timoni -n default delete podinfo
 | `sync: interval:`             | `int`                 | `60`         | Reconcile interval in minutes                                       |
 | `sync: timeout:`              | `int`                 | `5`          | Timeout in minutes                                                  |
 | `sync: serviceAccountName:`   | `string`              | `""`         | Service account to impersonate                                      |
-| `sync: targetNamespace:`      | `string`              | `""`         | specify the namespace to which the Helm release is made             |
+| `sync: targetNamespace:`      | `string`              | `""`         | Specify the namespace to which the Helm release is made. When not specified, it defaults to the instance namespace. |
 | `sync: createNamespace:`      | `bool`                | `false`      | Instructs Helm to create the target namespace if it does not exist  |
 | `sync: disableWait:`          | `bool`                | `false`      | Disables waiting for resource readiness after install/upgrade       |
 | `dependsOn:`                  | `[...{name: string}]` | `{}`         | List of dependencies                                                |

--- a/modules/flux-helm-release/README.md
+++ b/modules/flux-helm-release/README.md
@@ -33,6 +33,7 @@ timoni -n default delete podinfo
 | `sync: interval:`             | `int`                 | `60`         | Reconcile interval in minutes                                       |
 | `sync: timeout:`              | `int`                 | `5`          | Timeout in minutes                                                  |
 | `sync: serviceAccountName:`   | `string`              | `""`         | Service account to impersonate                                      |
+| `sync: targetNamespace:`      | `string`              | `""`         | specify the namespace to which the Helm release is made             |
 | `sync: createNamespace:`      | `bool`                | `false`      | Instructs Helm to create the target namespace if it does not exist  |
 | `sync: disableWait:`          | `bool`                | `false`      | Disables waiting for resource readiness after install/upgrade       |
 | `dependsOn:`                  | `[...{name: string}]` | `{}`         | List of dependencies                                                |

--- a/modules/flux-helm-release/templates/config.cue
+++ b/modules/flux-helm-release/templates/config.cue
@@ -35,6 +35,7 @@ import (
 		interval:            int | *60
 		timeout:             int | *5
 		disableWait:         bool | *false
+		createNamespace:     bool | *false
 		serviceAccountName?: string
 		targetNamespace?:    string
 	}

--- a/modules/flux-helm-release/templates/helmrelease.cue
+++ b/modules/flux-helm-release/templates/helmrelease.cue
@@ -53,6 +53,7 @@ import (
 		install: {
 			crds: "Create"
 			remediation: retries: #config.sync.retries
+			createNamespace:    #config.sync.createNamespace
 			disableWait:        #config.sync.disableWait
 			disableWaitForJobs: #config.sync.disableWait
 		}


### PR DESCRIPTION
We would like to be able to target non-existing namespaces in the HelmReleases of our timoni bundles.

This changes adds a sync.createNamespace optional value to activate this option.