### PR TITLE
Run end-to-end tests with Kubernetes 1.35

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -45,7 +45,7 @@ jobs:
         run: |
           kind create cluster \
           --config ./test/cluster/kind.yaml \
-          --image ghcr.io/fluxcd/kindest/node:v1.33.0-amd64
+          --image ghcr.io/fluxcd/kindest/node:v1.35.1-amd64
       - name: Push modules
         run: |
           timoni mod push ./modules/flux-aio ${FLUX_MODULE_URL} -v ${FLUX_MODULE_VERSION}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # flux-aio
 
-[![flux](https://img.shields.io/badge/flux-v2.7.3-9cf)](https://fluxcd.io)
+[![flux](https://img.shields.io/badge/flux-v2.7.5-9cf)](https://fluxcd.io)
 [![test](https://github.com/stefanprodan/flux-aio/workflows/test/badge.svg)](https://github.com/stefanprodan/flux-aio/actions)
 [![license](https://img.shields.io/github/license/stefanprodan/flux-aio.svg)](https://github.com/stefanprodan/flux-aio/blob/main/LICENSE)
 [![release](https://img.shields.io/github/release/stefanprodan/flux-aio/all.svg)](https://github.com/stefanprodan/flux-aio/releases)
@@ -18,7 +18,7 @@ This distribution is optimized for running [Flux](https://fluxcd.io) on:
 - Serverless clusters for cost optimisation (EKS Fargate)
 
 The versioning of this distribution follows semver with the following format:
-`<flux version>-<distribution release number>`, e.g. `2.7.3-0`.
+`<flux version>-<distribution release number>`, e.g. `2.7.5-0`.
 
 ## Documentation
 


### PR DESCRIPTION
Bump Kubernetes in e2e to v1.35.1